### PR TITLE
Poprawki

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+composer.lock
+vendor
+node_modules
+package-lock.json
+source/assets/build/mix-manifest.json
+build*

--- a/config.php
+++ b/config.php
@@ -38,12 +38,12 @@ return (array)$yaml_config + [
             'excerpt' => function ($page) {
                 $tresc = $page->getContent();
                 preg_match('|<p[^>]*>(.*)</p>|siU', $tresc, $matches);
-                return isset($matches[1]) ? Str::of($matches[1])->words(40, '… <b>Czytaj dalej</b>') : Str::of(strip_tags($tresc))->words(40, '… <b>Czytaj dalej</b>');
+                return Str::of(strip_tags(isset($matches[1]) ? $matches[1] : $tresc))->words(40) . ' <b class="inline-block">Czytaj dalej →</b>';
             },
             'longerExcerpt' => function ($page) {
                 $tresc = $page->getContent();
                 preg_match('|<p[^>]*>(.*)</p>|siU', $tresc, $matches);
-                return isset($matches[1]) ? Str::of($matches[1])->words(120, '… <b>Czytaj dalej</b>') : Str::of(strip_tags($tresc))->words(120, '… <b>Czytaj dalej</b>');
+                return Str::of(strip_tags(isset($matches[1]) ? $matches[1] : $tresc))->words(120) . ' <b class="inline-block">Czytaj dalej →</b>';
             }
         ],
         'krok_po_kroku' => [
@@ -57,7 +57,7 @@ return (array)$yaml_config + [
             'excerpt' => function ($page) {
                 $tresc = $page->getContent();
                 preg_match('|<p[^>]*>(.*)</p>|siU', $tresc, $matches);
-                return isset($matches[1]) ? Str::of($matches[1])->words(80, '… <b>Czytaj dalej</b>') : Str::of(strip_tags($tresc))->words(80, '… <b>Czytaj dalej</b>');
+                return Str::of(strip_tags(isset($matches[1]) ? $matches[1] : $tresc))->words(80) . ' <b class="inline-block">Czytaj dalej →</b>';
             }
         ],
         'aktualnosci' => [

--- a/config.php
+++ b/config.php
@@ -38,12 +38,12 @@ return (array)$yaml_config + [
             'excerpt' => function ($page) {
                 $tresc = $page->getContent();
                 preg_match('|<p[^>]*>(.*)</p>|siU', $tresc, $matches);
-                return Str::of(strip_tags(isset($matches[1]) ? $matches[1] : $tresc))->words(40) . ' <b class="inline-block">Czytaj dalej →</b>';
+                return Str::of(strip_tags($matches[1] ?? $tresc))->words(40) . ' <b class="inline-block">Czytaj dalej →</b>';
             },
             'longerExcerpt' => function ($page) {
                 $tresc = $page->getContent();
                 preg_match('|<p[^>]*>(.*)</p>|siU', $tresc, $matches);
-                return Str::of(strip_tags(isset($matches[1]) ? $matches[1] : $tresc))->words(120) . ' <b class="inline-block">Czytaj dalej →</b>';
+                return Str::of(strip_tags($matches[1] ?? $tresc))->words(120) . ' <b class="inline-block">Czytaj dalej →</b>';
             }
         ],
         'krok_po_kroku' => [
@@ -57,7 +57,7 @@ return (array)$yaml_config + [
             'excerpt' => function ($page) {
                 $tresc = $page->getContent();
                 preg_match('|<p[^>]*>(.*)</p>|siU', $tresc, $matches);
-                return Str::of(strip_tags(isset($matches[1]) ? $matches[1] : $tresc))->words(80) . ' <b class="inline-block">Czytaj dalej →</b>';
+                return Str::of(strip_tags($matches[1] ?? $tresc))->words(80) . ' <b class="inline-block">Czytaj dalej →</b>';
             }
         ],
         'aktualnosci' => [

--- a/source/__source/assets/sass/_base.scss
+++ b/source/__source/assets/sass/_base.scss
@@ -227,7 +227,7 @@ table {
         @apply .px-4;
         @apply .border-gray-300;
         @include dark {
-            @apply .border-gray-800;
+            @apply .border-gray-900;
         }
         &:not(:first-child){
             @apply .border-l;

--- a/source/__source/assets/sass/_misc.scss
+++ b/source/__source/assets/sass/_misc.scss
@@ -323,7 +323,7 @@ mark {
         .current > a {
             @apply .font-extrabold;
             @apply .text-pink-700;
-            .dark & {
+            @include dark {
                 @apply .text-purple-400;
             }
         }


### PR DESCRIPTION
Poprawiłem zgłoszony problem, że jeśli artykuł zawiera na początku link, to wycinek na stronie głównej się rozlatuje.
Oprócz tego wprowadziłem drobne poprawki stylistyczne, np linie tabeli w trybie ciemnym.